### PR TITLE
nix: fix rust-analyzer missing completions

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,6 +2,7 @@
   mkShell,
   rust-analyzer,
   rustfmt,
+  rustc,
   clippy,
   cargo,
   rustPlatform,
@@ -13,6 +14,7 @@ mkShell {
     rustfmt
     clippy
     cargo
+    rustc
   ];
 
   RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";


### PR DESCRIPTION
Added rustc into devShell to fix missing rust-analyzer hover docs

### Before
<img width="440" height="213" alt="image" src="https://github.com/user-attachments/assets/04a81b10-4ce1-4262-9ac9-fccbc9ec27c7" />
<img width="345" height="222" alt="image" src="https://github.com/user-attachments/assets/dacd846a-a8a8-4e43-a872-fa1dc5a75c93" />
<img width="983" height="283" alt="image" src="https://github.com/user-attachments/assets/73cec829-b1d1-4bb3-a134-427b3ec8c28f" />

### After
<img width="891" height="592" alt="image" src="https://github.com/user-attachments/assets/1dd6dd40-6a53-49e9-98ff-23362158794c" />
<img width="1101" height="518" alt="image" src="https://github.com/user-attachments/assets/c1d90044-7813-4942-93b1-2a8e35355936" />
<img width="617" height="256" alt="image" src="https://github.com/user-attachments/assets/1c960d26-2798-4e3b-870a-ec5581c69acc" />