### PR TITLE
nix: incremental builds with crane

### DIFF
--- a/.github/workflows/nix-cache.yaml
+++ b/.github/workflows/nix-cache.yaml
@@ -1,0 +1,19 @@
+name: "Populate cachix cache"
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths: [ 'src/**.rs', 'Cargo.toml', 'Cargo.lock', 'nix/package.nix' ]
+jobs:
+  populate-cache:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v14
+      with:
+        name: nyx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix build

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1754725699,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,20 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+  inputs.crane.url = "github:ipetkov/crane";
 
   outputs = {
     self,
     nixpkgs,
+    crane,
   }: let
     systems = ["x86_64-linux" "aarch64-linux"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
     pkgsForEach = nixpkgs.legacyPackages;
   in {
     packages = forEachSystem (system: {
-      default = pkgsForEach.${system}.callPackage ./nix/package.nix {};
+      default = pkgsForEach.${system}.callPackage ./nix/package.nix {
+        craneLib = crane.mkLib pkgsForEach.${system};
+      };
     });
 
     devShells = forEachSystem (system: {


### PR DESCRIPTION
- addition of crane to flake inputs
- building stash package leveraging craneLib
- reliable incremental builds with custom addition that ensures cache hit even when package version changes

Heyya raf, malded over this for the entirety of yesterday and came up with this. With this we can ensure that stash is incrementally built. Ofc, the first build will build everything (stash-deps and stash), but every sucessive build after that will only build stash.

the following changes to code were tested to build incrementally (builds only stash and not stash-deps)
- [x] changes to code in src/
- [x] changes to version number
- [x] changes to non rust code (filtered out by cleanCargoSource) 

for now things that will cause a rebuild of deps would be
- adding or updating cargo dependencies
- renaming stash (can easily be fixed read comment in `nix/package.nix:L30`)