### PR TITLE
reset auto increment on stash wipe

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -290,6 +290,10 @@ impl ClipboardDb for SqliteClipboardDb {
       .conn
       .execute("DELETE FROM clipboard", [])
       .map_err(|e| StashError::Wipe(e.to_string()))?;
+    self
+      .conn
+      .execute("DELETE FROM sqlite_sequence WHERE name = 'clipboard'", [])
+      .map_err(|e| StashError::Wipe(e.to_string()))?;
     Ok(())
   }
 


### PR DESCRIPTION
Ensures that the clipboard table's id field's auto increment is reset to 1 when the stash wipe commands is run

### Tests performed
- [x] verified proposed behavior

### References
https://stackoverflow.com/questions/1601697/sqlite-reset-primary-key-field