### PR TITLE
Preserve clipboard MIME types and prefer plain text offers

### DIFF
--- a/src/commands/store.rs
+++ b/src/commands/store.rs
@@ -40,6 +40,7 @@ impl StoreCommand for SqliteClipboardDb {
         max_size,
         None, // no pre-computed hash for CLI store
         None, // no mime types for CLI store
+        None, // no selected mime for CLI store
       )?;
       log::info!("entry stored");
     }

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -163,38 +163,7 @@ fn negotiate_mime_type(
     return Ok((Box::new(reader) as Box<dyn Read>, mime_str, offered));
   }
 
-  let chosen = if preference == "image" {
-    // Pick the first offered image type, fall back to first overall
-    offered
-      .iter()
-      .find(|m| m.starts_with("image/"))
-      .or_else(|| offered.first())
-  } else {
-    // XXX: When preference is "any", deprioritize HTML-flavored types if a
-    // more concrete type is available. Browsers and Electron apps put
-    // text/html first even for "Copy Image", but the HTML is just a wrapper
-    // (<img src="...">), i.e., never what the user wants in a clipboard
-    // manager. Firefox also lists Mozilla-internal wrappers
-    // (text/_moz_htmlcontext, text/_moz_htmlinfo) ahead of the plain-text
-    // representation, and those are UTF-16 encoded, so storing them mislabels
-    // the entry as text/plain and truncates at the first NUL byte on paste.
-    // Prefer image/* first, then any non-HTML-like type, and fall back to the
-    // HTML wrapper only as a last resort.
-    let has_image = offered.iter().any(|m| m.starts_with("image/"));
-    if has_image {
-      offered
-        .iter()
-        .find(|m| m.starts_with("image/"))
-        .or_else(|| offered.first())
-    } else if offered.first().is_some_and(|m| is_html_like(m)) {
-      offered
-        .iter()
-        .find(|m| !is_html_like(m))
-        .or_else(|| offered.first())
-    } else {
-      offered.first()
-    }
-  };
+  let chosen = pick_mime(&offered, preference);
 
   match chosen {
     Some(mime_str) => {
@@ -395,6 +364,7 @@ impl WatchCommand for SqliteClipboardDb {
                   max_size,
                   content_hash,
                   Some(mime_types_for_persist.clone()),
+                  Some(selected_mime.clone()),
                 )
                 .await
               {
@@ -503,10 +473,11 @@ impl WatchCommand for SqliteClipboardDb {
   }
 }
 
-/// Given ordered offers and a preference, return the
-/// chosen MIME type. This mirrors the selection logic in
-/// [`negotiate_mime_type`] without requiring a Wayland connection.
-#[cfg(test)]
+/// Given ordered offers and a preference, return the chosen MIME type.
+///
+/// For the default preference, images win over HTML wrappers; otherwise plain
+/// text wins over URI lists and other non-HTML representations when the offer
+/// begins with an HTML wrapper.
 fn pick_mime<'a>(
   offered: &'a [String],
   preference: &str,
@@ -526,7 +497,8 @@ fn pick_mime<'a>(
     } else if offered.first().is_some_and(|m| is_html_like(m)) {
       offered
         .iter()
-        .find(|m| !is_html_like(m))
+        .find(|m| m.as_str() == "text/plain" || m.starts_with("text/plain;"))
+        .or_else(|| offered.iter().find(|m| !is_html_like(m)))
         .or_else(|| offered.first())
     } else {
       offered.first()
@@ -598,6 +570,19 @@ mod tests {
     // html + plain with no image type; plain text wins over html.
     let offered = vec!["text/html".to_string(), "text/plain".to_string()];
     assert_eq!(pick_mime(&offered, "any").unwrap(), "text/plain");
+  }
+
+  #[test]
+  fn test_pick_plain_text_over_uri_list_after_html() {
+    let offered = vec![
+      "text/html".to_string(),
+      "text/uri-list".to_string(),
+      "text/plain;charset=utf-8".to_string(),
+    ];
+    assert_eq!(
+      pick_mime(&offered, "any").unwrap(),
+      "text/plain;charset=utf-8"
+    );
   }
 
   #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -283,6 +283,7 @@ pub trait ClipboardDb {
     max_size: usize,
     content_hash: Option<i64>,
     mime_types: Option<&[String]>,
+    selected_mime: Option<&str>,
   ) -> Result<i64, StashError>;
 
   fn trim_db(&self, max_items: u64) -> Result<(), StashError>;
@@ -572,6 +573,7 @@ impl ClipboardDb for SqliteClipboardDb {
     max_size: usize,
     content_hash: Option<i64>,
     mime_types: Option<&[String]>,
+    selected_mime: Option<&str>,
   ) -> Result<i64, StashError> {
     let mut buf = Vec::new();
     if input.read_to_end(&mut buf).is_err() || buf.is_empty() {
@@ -606,7 +608,9 @@ impl ClipboardDb for SqliteClipboardDb {
       hash
     });
 
-    let mime = crate::mime::detect_mime(&buf);
+    let mime = selected_mime
+      .map(str::to_owned)
+      .or_else(|| crate::mime::detect_mime(&buf));
 
     // Try to load regex from systemd credential file, then env var
     let regex = load_sensitive_regex();
@@ -653,6 +657,7 @@ impl ClipboardDb for SqliteClipboardDb {
       content_hash,
       max_dedupe_search,
       mime_types_json.as_deref(),
+      mime.as_deref(),
     )? {
       return Ok(id);
     }
@@ -928,6 +933,7 @@ impl SqliteClipboardDb {
     content_hash: i64,
     max: u64,
     mime_types_json: Option<&str>,
+    mime: Option<&str>,
   ) -> Result<Option<i64>, StashError> {
     let mut stmt = self
       .conn
@@ -958,14 +964,14 @@ impl SqliteClipboardDb {
         .map_err(|e| StashError::DeduplicationRemove(e.to_string().into()))?;
     }
 
-    // Move the kept entry to the top; refresh mime_types only when the new
-    // store provides them (COALESCE preserves the prior value otherwise).
+    // Move the kept entry to the top; refresh MIME metadata only when the new
+    // store provides it (COALESCE preserves the prior value otherwise).
     self
       .conn
       .execute(
         "UPDATE clipboard SET last_accessed = ?2, mime_types = COALESCE(?3, \
-         mime_types) WHERE id = ?1",
-        params![keep_id, Self::now() as i64, mime_types_json],
+         mime_types), mime = COALESCE(?4, mime) WHERE id = ?1",
+        params![keep_id, Self::now() as i64, mime_types_json, mime],
       )
       .map_err(|e| StashError::Store(e.to_string().into()))?;
 
@@ -1738,6 +1744,7 @@ mod tests {
         DEFAULT_MAX_ENTRY_SIZE,
         None,
         None,
+        None,
       )
       .expect("Failed to store entry");
 
@@ -1762,6 +1769,7 @@ mod tests {
         DEFAULT_MAX_ENTRY_SIZE,
         None,
         None,
+        None,
       )
       .expect("Failed to store URI list");
 
@@ -1772,6 +1780,27 @@ mod tests {
       })
       .expect("Failed to get mime");
     assert_eq!(mime, Some("text/uri-list".to_string()));
+  }
+
+  #[test]
+  fn test_store_preserves_selected_file_operation_mime() {
+    let db = test_db();
+    let id = db
+      .store_entry(
+        std::io::Cursor::new(b"cut\nfile:///tmp/example".to_vec()),
+        100,
+        1000,
+        None,
+        None,
+        DEFAULT_MAX_ENTRY_SIZE,
+        None,
+        Some(&["x-special/gnome-copied-files".to_string()]),
+        Some("x-special/gnome-copied-files"),
+      )
+      .expect("Failed to store file operation");
+
+    let (_, _, mime) = db.copy_entry(id).expect("Failed to copy entry");
+    assert_eq!(mime.as_deref(), Some("x-special/gnome-copied-files"));
   }
 
   #[test]
@@ -1795,6 +1824,7 @@ mod tests {
         None,
         None,
         DEFAULT_MAX_ENTRY_SIZE,
+        None,
         None,
         None,
       )
@@ -1835,6 +1865,7 @@ mod tests {
       DEFAULT_MAX_ENTRY_SIZE,
       None,
       None,
+      None,
     )
     .expect("Failed to store image");
 
@@ -1862,6 +1893,7 @@ mod tests {
       None,
       None,
       DEFAULT_MAX_ENTRY_SIZE,
+      None,
       None,
       None,
     )
@@ -1947,6 +1979,7 @@ mod tests {
         DEFAULT_MAX_ENTRY_SIZE,
         None,
         None,
+        None,
       )
       .expect("Failed to store first");
     let id2 = db
@@ -1957,6 +1990,7 @@ mod tests {
         None,
         None,
         DEFAULT_MAX_ENTRY_SIZE,
+        None,
         None,
         None,
       )
@@ -2001,6 +2035,7 @@ mod tests {
         DEFAULT_MAX_ENTRY_SIZE,
         None,
         None,
+        None,
       )
       .expect("Failed to store");
     }
@@ -2024,6 +2059,7 @@ mod tests {
       DEFAULT_MAX_ENTRY_SIZE,
       None,
       None,
+      None,
     );
     assert!(matches!(result, Err(StashError::EmptyOrTooLarge)));
   }
@@ -2038,6 +2074,7 @@ mod tests {
       None,
       None,
       DEFAULT_MAX_ENTRY_SIZE,
+      None,
       None,
       None,
     );
@@ -2058,6 +2095,7 @@ mod tests {
       DEFAULT_MAX_ENTRY_SIZE,
       None,
       None,
+      None,
     );
     assert!(matches!(result, Err(StashError::TooLarge(5000000))));
   }
@@ -2073,6 +2111,7 @@ mod tests {
         None,
         None,
         DEFAULT_MAX_ENTRY_SIZE,
+        None,
         None,
         None,
       )
@@ -2103,6 +2142,7 @@ mod tests {
       DEFAULT_MAX_ENTRY_SIZE,
       None,
       None,
+      None,
     )
     .expect("Failed to store");
     db.store_entry(
@@ -2112,6 +2152,7 @@ mod tests {
       None,
       None,
       DEFAULT_MAX_ENTRY_SIZE,
+      None,
       None,
       None,
     )
@@ -2141,6 +2182,7 @@ mod tests {
         None,
         None,
         DEFAULT_MAX_ENTRY_SIZE,
+        None,
         None,
         None,
       )
@@ -2222,6 +2264,7 @@ mod tests {
         None,
         None,
         DEFAULT_MAX_ENTRY_SIZE,
+        None,
         None,
         None,
       )
@@ -2308,6 +2351,7 @@ mod tests {
         None,
         None,
         DEFAULT_MAX_ENTRY_SIZE,
+        None,
         None,
         None,
       )
@@ -2544,6 +2588,7 @@ mod tests {
           None,
           None,
           DEFAULT_MAX_ENTRY_SIZE,
+          None,
           None,
           None,
         )

--- a/src/db/nonblocking.rs
+++ b/src/db/nonblocking.rs
@@ -29,6 +29,7 @@ impl AsyncClipboardDb {
     max_size: usize,
     content_hash: Option<i64>,
     mime_types: Option<Vec<String>>,
+    selected_mime: Option<String>,
   ) -> Result<i64, StashError> {
     let path = self.db_path.clone();
     blocking::unblock(move || {
@@ -42,6 +43,7 @@ impl AsyncClipboardDb {
         max_size,
         content_hash,
         mime_types.as_deref(),
+        selected_mime.as_deref(),
       )
     })
     .await
@@ -164,6 +166,7 @@ mod tests {
           5_000_000,
           None,
           None,
+          None,
         )
         .await
         .expect("Failed to store entry");
@@ -200,6 +203,7 @@ mod tests {
           None,
           None,
           5_000_000,
+          None,
           None,
           None,
         )
@@ -241,6 +245,7 @@ mod tests {
           None,
           None,
           5_000_000,
+          None,
           None,
           None,
         )
@@ -299,6 +304,7 @@ mod tests {
           5_000_000,
           None,
           None,
+          None,
         )
         .await
         .expect("Failed with original");
@@ -311,6 +317,7 @@ mod tests {
           None,
           None,
           5_000_000,
+          None,
           None,
           None,
         )
@@ -352,8 +359,10 @@ mod tests {
           let db = async_db.clone();
           let data = format!("concurrent test {}", i).into_bytes();
           smol::spawn(async move {
-            db.store_entry(data, 100, 1000, None, None, 5_000_000, None, None)
-              .await
+            db.store_entry(
+              data, 100, 1000, None, None, 5_000_000, None, None, None,
+            )
+            .await
           })
         })
         .collect();


### PR DESCRIPTION
Improves clipboard MIME type handling and metadata preservation, especially for file operations and plain text detection alongside a tiny refactor to how the selected MIME type is passed and stored throughout the codebase. Aims to fix #100 but I'm hopeful that through ensuring that when a specific MIME type is chosen (such as for file operations), it is correctly preserved in the database and thus the bug is fixed. We also prefer plain text is over URI lists when HTML wrappers are present.

Needs testing and feedback.